### PR TITLE
feat: aws transcribe를 사용해서 stt 구현 (정확도 떨어짐)

### DIFF
--- a/src/public/js/audio-processor.js
+++ b/src/public/js/audio-processor.js
@@ -23,9 +23,14 @@ class AudioProcessor extends AudioWorkletProcessor {
     // Math.min, max 사용해서 범위 잡아주고 곱해줌.
     // 0x7FFF는 32767를 16진수로 표현한 것
     // 정수로 표현하는거라 소숫점이 잘리긴 하지만 실제 음질에는 영향 거의 X
-    convertFloat32ToInt16(buffer){
-        return buffer.map(value => Math.max(-1, Math.min(1, value)) * 0x7FFF);
+    convertFloat32ToInt16(buffer) {
+        const int16Buffer = new Int16Array(buffer.length);
+        for (let i = 0; i < buffer.length; i++) {
+            int16Buffer[i] = Math.max(-1, Math.min(1, buffer[i])) * 0x7FFF;
+        }
+        return int16Buffer;
     }
+    
 }
 
 

--- a/src/server.js
+++ b/src/server.js
@@ -31,7 +31,7 @@ const LanguageCode = "ko-KR";
 const MediaEncoding = "pcm";
 const MediaSampleRateHertz = 16000;  // 추천되는건 16000
 const targetChunkSize = 16000; // 16kb target chunk size
-const chunkInterval = 0.5; // 0.5 seconds
+const chunkInterval = 500; // 0.5 seconds
 
 async function startTranscribe() {
     console.log("startTranscribe function called");
@@ -97,11 +97,11 @@ async function startTranscribe() {
         
         // for await...of를 사용하여 TranscriptResultStream 처리
         for await (const event of response.TranscriptResultStream) {
-            // console.log(event);
+            console.log(event);
             const transcriptEvent = event.TranscriptEvent;
             if (transcriptEvent && transcriptEvent.Transcript) {
                 const results = transcriptEvent.Transcript.Results;
-                // console.log("Transcribe event results : ", results);
+                console.log("Transcribe event results : ", results);
                 results.forEach(result => {
                     if (!result.IsPartial) {
                         const transcript = result.Alternatives[0].Transcript;

--- a/src/server.js
+++ b/src/server.js
@@ -22,16 +22,20 @@ const wsServer = SocketIO(httpServer);
 
 // 오디오 데이터를 받을 스트림
 let audioStream = new PassThrough();
+
+
 let transcribeSessionActive = false;
 let abortController = null;
 
 const LanguageCode = "ko-KR";
 const MediaEncoding = "pcm";
-const MediaSampleRateHertz = 48000;  // 추천되는건 16000
+const MediaSampleRateHertz = 16000;  // 추천되는건 16000
 const targetChunkSize = 16000; // 16kb target chunk size
-const chunkInterval = 500; // 0.5 seconds
+const chunkInterval = 0.5; // 0.5 seconds
 
 async function startTranscribe() {
+    console.log("startTranscribe function called");
+
     abortController = new AbortController();
     const client = new TranscribeStreamingClient({
         region: process.env.AWS_REGION,
@@ -46,9 +50,13 @@ async function startTranscribe() {
         MediaEncoding,
         MediaSampleRateHertz,
         AudioStream: (async function* () {
+            // console.log("AudioStream generator started");
+
             let buffer = Buffer.alloc(0);
     
             for await (const chunk of audioStream) {
+                // console.log("Processing audio chunk in AudioStream");
+
                 if (!transcribeSessionActive) break;  // 세션 비활성화 시 루프 종료
                 buffer = Buffer.concat([buffer, chunk]);
     
@@ -83,16 +91,17 @@ async function startTranscribe() {
             command,
             {   
                 // AbortController 연결
-                signal: AbortController.signal
+                signal: abortController.signal
             } 
         );
         
         // for await...of를 사용하여 TranscriptResultStream 처리
         for await (const event of response.TranscriptResultStream) {
+            // console.log(event);
             const transcriptEvent = event.TranscriptEvent;
             if (transcriptEvent && transcriptEvent.Transcript) {
                 const results = transcriptEvent.Transcript.Results;
-                console.log("Transcribe event results : ", results);
+                // console.log("Transcribe event results : ", results);
                 results.forEach(result => {
                     if (!result.IsPartial) {
                         const transcript = result.Alternatives[0].Transcript;
@@ -138,6 +147,7 @@ wsServer.on("connection", socket => {
             wsServer.to(roomName).emit("notification", `${email}님이 입장하셨습니다.`);
             // AWS Transcribe 시작
             if(userCount > 0)
+                console.log("시작");
                 startTranscribe();
         }
     });
@@ -145,6 +155,7 @@ wsServer.on("connection", socket => {
         // 클라이언트에서 받은 오디오 데이터를 audioStream에 추가
         // console.log("Received audio chunk size:", chunk.length); 
         audioStream.write(chunk);
+        // console.log("Chunk written to audioStream");
     });
     // caller가 offer로 보낸 sdp를 통화를 연결하려는 방에 보냄
     socket.on("offer", (offer, roomName)=>{


### PR DESCRIPTION
## 문제 사항: stt chunk에 빈 값이 들어옴

<img width="400" alt="image (4)" src="https://github.com/user-attachments/assets/99516480-c75a-43c1-8b3e-408695714f8a">

TranscriptEvent가 수신되는 것은 확인했으나 번역된 결과값(Results)에 아무 값이 들어오지 않음

## 문제 원인 : 오디오 계산 문제

이전 코드

```jsx
convertFloat32ToInt16(buffer){
        return buffer.map(value => Math.max(-1, Math.min(1, value)) * 0x7FFF);
    }
```

`convertFloat32ToInt16` **반환 형식 확인**

`convertFloat32ToInt16` 함수가 현재 `buffer.map(...)`을 반환하고 있지만, `map`은 `Float32Array`를 반환한다. `Int16Array` 형식으로 명확히 반환되도록 수정이 필요하다.

변경 코드

```jsx
convertFloat32ToInt16(buffer) {
        const int16Buffer = new Int16Array(buffer.length);
        for (let i = 0; i < buffer.length; i++) {
            int16Buffer[i] = Math.max(-1, Math.min(1, buffer[i])) * 0x7FFF;
        }
        return int16Buffer;
    }
```

- 이렇게 하면 `Int16Array` 형식이 명확히 보장된다.

## 문제 해결

<img width="408" alt="스크린샷 2024-10-29 오후 4 30 55" src="https://github.com/user-attachments/assets/a5672c81-d9d0-412a-8388-76018653dd0b">
<img width="346" alt="image (5)" src="https://github.com/user-attachments/assets/a4695530-4192-44ae-8680-8e2649dc9f7c">

Text로 반환하는 것까지 성공

하지만 “안녕하세요”를 연발했으나 사진과 같이 

“아”

“음”

“무”

어쩌다 얻어걸려서 “안녕하세요.” 가 출력되었고

**심지어 “그런 경우가 없더라고요.” 라는 말이 출력됨 (내가 한말아님)**

- 없는 말을 지어내는 경우는 심각한 상황이라 판단

<br>

말을 하지 않아도 반환 값이 나오는 것으로 보아

→ 음성 데이터가 큰 대역폭을 담당해서 그런가 주위 소리도 들어가는 거 같음

## 결론 (현재 상황)

Speach To Text를 구현하긴 했으나 다음과 같은 문제점이 있음 

1. 정확도 낮음
2. 이상한 말 지어냄
3. 주위 소리가 들어감

⇒ 성능 향상이 필요함